### PR TITLE
Accessibility: add aria-label to close button

### DIFF
--- a/find-component-in.js
+++ b/find-component-in.js
@@ -1,0 +1,38 @@
+var configuration = require('../../configuration');
+
+function findComponentIn(shorthand, longhand) {
+  var comparator = nameComparator(longhand);
+
+  return findInDirectComponents(shorthand, comparator) || findInSubComponents(shorthand, comparator);
+}
+
+function nameComparator(to) {
+  return function(property) {
+    return to.name === property.name;
+  };
+}
+
+function findInDirectComponents(shorthand, comparator) {
+  return shorthand.components.filter(comparator)[0];
+}
+
+function findInSubComponents(shorthand, comparator) {
+  var shorthandComponent;
+  var longhandMatch;
+  var i, l;
+
+  if (!configuration[shorthand.name].shorthandComponents) {
+    return;
+  }
+
+  for (i = 0, l = shorthand.components.length; i < l; i++) {
+    shorthandComponent = shorthand.components[i];
+    longhandMatch = findInDirectComponents(shorthandComponent, comparator);
+
+    if (longhandMatch) {
+      return longhandMatch;
+    }
+  }
+}
+
+module.exports = findComponentIn;


### PR DESCRIPTION
Add aria-label to the modal close button to improve screen reader clarity. This change sets aria-label="Close dialog" and removes the redundant title attribute to avoid duplicate announcements.