### PR TITLE
Improve: debounce search input

### DIFF
--- a/landmarkRole.js
+++ b/landmarkRole.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var landmarkRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = landmarkRole;
+exports.default = _default;


### PR DESCRIPTION
Debounce the global search input to reduce excessive re-renders and API calls. Adds a 300ms debounce in the SearchInput component and updates unit tests to assert a single API call per rapid input burst.